### PR TITLE
Fix DialogContent requires a DialogTitle warning

### DIFF
--- a/src/components/Overlays/Modal/Modal.tsx
+++ b/src/components/Overlays/Modal/Modal.tsx
@@ -16,6 +16,7 @@ import { useAppRootContext } from 'hooks/useAppRootContext';
 
 import { Drawer } from '@xelene/vaul-with-scroll-fix';
 
+import { VisuallyHidden } from 'components/Service/VisuallyHidden/VisuallyHidden';
 import { ModalClose } from './components/ModalClose/ModalClose';
 import { ModalHeader } from './components/ModalHeader/ModalHeader';
 import { ModalOverlay } from './components/ModalOverlay/ModalOverlay';
@@ -108,7 +109,9 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>(({
           ref={ref}
           className={classNames(styles.wrapper, className)}
           {...restProps}
+          aria-describedby={undefined}
         >
+          <VisuallyHidden><Drawer.Title /></VisuallyHidden>
           {header}
           <div className={styles.body}>
             {children}


### PR DESCRIPTION
This should fix #55 

![image](https://github.com/user-attachments/assets/e390ac3f-a16b-4734-b51d-0c266e9a2a17)

RadixUI which is used by Vaul, which is used by this library is quite opinionated when it comes to a11y. 

It requires to explicitly set `<Dialog.Title>` (for this library it is `<Drawer.TItle>`) and `<Dialog.Description>`

Here is reference issue in Radix: https://github.com/radix-ui/primitives/issues/2986

--

In this PR I just utilize `VisuallyHidden` and hack my way thorough this warning. The only thing that seems to be added to final DOM is this:

![image](https://github.com/user-attachments/assets/22b164a1-68ff-4ed0-9e8c-6c49a2dfdde2)

--

Thanks for the lib by the way :-) using it to craft a small pet project, works like charm :-) 