### PR TITLE
feat(Tappable): expose onPointerDown and onPointerCancel props

### DIFF
--- a/src/components/Service/Tappable/Tappable.tsx
+++ b/src/components/Service/Tappable/Tappable.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { AllHTMLAttributes, ElementType, forwardRef } from 'react';
+import { AllHTMLAttributes, ElementType, forwardRef, PointerEvent } from 'react';
 import styles from './Tappable.module.css';
 
 import { classNames } from 'helpers/classNames';
@@ -21,10 +21,22 @@ export const Tappable = forwardRef(({
   className,
   interactiveAnimation = 'background',
   readOnly,
+  onPointerDown,
+  onPointerCancel,
   ...restProps
 }: TappableProps, ref) => {
   const platform = usePlatform();
-  const { clicks, onPointerCancel, onPointerDown } = useRipple();
+  const { clicks, onPointerCancel: handleRipplePointerCancel, onPointerDown: handleRipplePointerDown } = useRipple();
+
+  const handlePointerDown = (e: PointerEvent<HTMLElement>) => {
+    onPointerDown?.(e);
+    handleRipplePointerDown(e);
+  };
+
+  const handlePointerCancel = (e: PointerEvent<HTMLElement>) => {
+    onPointerCancel?.(e);
+    handleRipplePointerCancel(e);
+  };
 
   const hasRippleEffect = platform === 'base' && interactiveAnimation === 'background' && !readOnly;
   return (
@@ -36,8 +48,8 @@ export const Tappable = forwardRef(({
         interactiveAnimation === 'opacity' && styles['wrapper--opacity'],
         className,
       )}
-      onPointerCancel={onPointerCancel}
-      onPointerDown={onPointerDown}
+      onPointerCancel={handlePointerCancel}
+      onPointerDown={handlePointerDown}
       readOnly={readOnly}
       {...restProps}
     >

--- a/src/components/Service/Tappable/Tappable.tsx
+++ b/src/components/Service/Tappable/Tappable.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { AllHTMLAttributes, ElementType, forwardRef, PointerEvent } from 'react';
+import { AllHTMLAttributes, ElementType, forwardRef } from 'react';
 import styles from './Tappable.module.css';
 
 import { classNames } from 'helpers/classNames';
+import { callMultiple } from 'helpers/function';
 import { usePlatform } from 'hooks/usePlatform';
 
 import { useRipple } from './components/Ripple/hooks/useRipple';
@@ -28,15 +29,9 @@ export const Tappable = forwardRef(({
   const platform = usePlatform();
   const { clicks, onPointerCancel: handleRipplePointerCancel, onPointerDown: handleRipplePointerDown } = useRipple();
 
-  const handlePointerDown = (e: PointerEvent<HTMLElement>) => {
-    onPointerDown?.(e);
-    handleRipplePointerDown(e);
-  };
+  const handlePointerDown = callMultiple(onPointerDown, handleRipplePointerDown);
 
-  const handlePointerCancel = (e: PointerEvent<HTMLElement>) => {
-    onPointerCancel?.(e);
-    handleRipplePointerCancel(e);
-  };
+  const handlePointerCancel = callMultiple(onPointerCancel, handleRipplePointerCancel);
 
   const hasRippleEffect = platform === 'base' && interactiveAnimation === 'background' && !readOnly;
   return (


### PR DESCRIPTION
Currently, the Button component in TelegramUI uses a Tappable under the hood, which relies on onPointerDown and onPointerCancel for the ripple effect via the [useRipple](https://github.com/Telegram-Mini-Apps/TelegramUI/blob/78231341ea121f574123abbceceba0f9679981f0/src/components/Service/Tappable/Tappable.tsx#L27) hook.

But since the Button doesn't explicitly support onPointerDown and onPointerUp props, there's no clean way to hook into these events from the outside. And even if you try to pass them manually through restProps, they end up replacing the internal handlers — which breaks the ripple effect.