### PR TITLE
Fixed SectionFooter text color

### DIFF
--- a/src/components/Blocks/Section/components/SectionFooter/SectionFooter.module.css
+++ b/src/components/Blocks/Section/components/SectionFooter/SectionFooter.module.css
@@ -16,5 +16,5 @@
 }
 
 .text {
-  color: var(--tgui--section_header_text_color);
+  color: var(--tgui--hint_color);
 }


### PR DESCRIPTION
How it looks like
<img width="378" height="170" alt="Image" src="https://github.com/user-attachments/assets/e5a37510-9bb3-4086-b771-3a49bf1a16e4" />
How it should be
<img width="375" height="171" alt="Image" src="https://github.com/user-attachments/assets/67935a04-bb1b-439c-8493-dcc184a99ace" />

I'm pretty sure that the footer text color needs to be `--tgui--hint_color` instead of `--tgui--section_header_text_color`

The error occurs on Windows "Telegram Desktop"